### PR TITLE
Move FOB/PageObjectExtension to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "php": "^7.2",
 
         "sylius/sylius": "~1.3.0",
-        "friendsofsymfony/jsrouting-bundle": "^2.2",
-        "friends-of-behat/page-object-extension": "^0.2.0"
+        "friendsofsymfony/jsrouting-bundle": "^2.2"
     },
     "require-dev": {
         "behat/behat": "^3.3",
@@ -32,6 +31,7 @@
         "behat/mink-selenium2-driver": "^1.3",
         "friends-of-behat/context-service-extension": "^1.2",
         "friends-of-behat/cross-container-extension": "^1.1",
+        "friends-of-behat/page-object-extension": "^0.2.0",
         "friends-of-behat/service-container-extension": "^1.0",
         "friends-of-behat/symfony-extension": "^1.2.1",
         "friends-of-behat/variadic-extension": "^1.1",


### PR DESCRIPTION
Mentioned in https://github.com/Sylius/AdminOrderCreationPlugin/pull/69#discussion_r213639884