### PR TITLE
Only one payment method allowed

### DIFF
--- a/features/creating_order/creating_simple_order.feature
+++ b/features/creating_order/creating_simple_order.feature
@@ -40,3 +40,8 @@ Feature: Creating simple order
     Scenario: Trying to create an order for a new customer without email
         When I try to create a new order for a new customer without email
         Then I should be notified that customer email cannot be empty
+
+    Scenario: Being unable to add multiple payment methods
+        When I create a new order for "jon.snow@the-wall.com" and channel "United States"
+        And I select "Cash on Delivery" payment method
+        Then adding another payment method should not be possible

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+                    http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+    <class name="Sylius\Component\Core\Model\Order">
+        <property name="payments">
+            <constraint name="Count">
+                <option name="min">1</option>
+                <option name="max">1</option>
+                <option name="groups">sylius</option>
+            </constraint>
+        </property>
+    </class>
+</constraint-mapping>

--- a/src/Resources/views/Order/create.html.twig
+++ b/src/Resources/views/Order/create.html.twig
@@ -33,6 +33,14 @@
     <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
     <script>
         $(document).ready(function() {
+            $('body').on('DOMNodeInserted', '#sylius_admin_order_creation_new_order_payments [data-form-collection="item"]', function() {
+                $('#sylius_admin_order_creation_new_order_payments [data-form-collection="add"]').hide();
+            });
+
+            $('body').on('DOMNodeRemoved', '#sylius_admin_order_creation_new_order_payments [data-form-collection="item"]', function() {
+                $('#sylius_admin_order_creation_new_order_payments [data-form-collection="add"]').show();
+            });
+
             $('#sylius_admin_order_creation_new_order_shipments [data-form-collection="add"]').on('click', function(e) {
                 if (!canShippingMethodBeProvided()) {
                     e.stopPropagation();

--- a/tests/Behat/Context/Admin/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Admin/ManagingOrdersContext.php
@@ -540,4 +540,12 @@ final class ManagingOrdersContext implements Context
     {
         Assert::false($this->orderCreateFormElement->areProductsVisible());
     }
+
+    /**
+     * @Then adding another payment method should not be possible
+     */
+    public function addingAnotherPaymentMethodShouldNotBePossible(): void
+    {
+        Assert::false($this->orderCreateFormElement->isAddPaymentButtonVisible());
+    }
 }

--- a/tests/Behat/Element/Admin/OrderCreateFormElement.php
+++ b/tests/Behat/Element/Admin/OrderCreateFormElement.php
@@ -270,6 +270,7 @@ class OrderCreateFormElement extends Element implements OrderCreateFormElementIn
             ;
         });
     }
+
     private function waitForFormToLoad(): void
     {
         $form = $this->getDocument()->find('css', '[name="sylius_admin_order_creation_new_order"]');
@@ -280,9 +281,8 @@ class OrderCreateFormElement extends Element implements OrderCreateFormElementIn
 
     public function isAddPaymentButtonVisible(): bool
     {
-        return $this
-                ->getElement('payments')
-                ->find('css', '[data-form-collection="Add"]') !== null
+        return
+            $this->getElement('payments')->find('css', '[data-form-collection="add"]')->isVisible()
         ;
     }
 }

--- a/tests/Behat/Element/Admin/OrderCreateFormElement.php
+++ b/tests/Behat/Element/Admin/OrderCreateFormElement.php
@@ -270,12 +270,19 @@ class OrderCreateFormElement extends Element implements OrderCreateFormElementIn
             ;
         });
     }
-
     private function waitForFormToLoad(): void
     {
         $form = $this->getDocument()->find('css', '[name="sylius_admin_order_creation_new_order"]');
         $this->getDocument()->waitFor(1000, function () use ($form) {
             return !$form->hasClass('loading');
         });
+    }
+
+    public function isAddPaymentButtonVisible(): bool
+    {
+        return $this
+                ->getElement('payments')
+                ->find('css', '[data-form-collection="Add"]') !== null
+        ;
     }
 }

--- a/tests/Behat/Element/Admin/OrderCreateFormElementInterface.php
+++ b/tests/Behat/Element/Admin/OrderCreateFormElementInterface.php
@@ -42,4 +42,6 @@ interface OrderCreateFormElementInterface
     public function placeOrder(): void;
 
     public function getShippingMethodsValidationMessage(): string;
+
+    public function isAddPaymentButtonVisible(): bool;
 }


### PR DESCRIPTION
<img width="1164" alt="screen shot 2018-09-05 at 10 03 47" src="https://user-images.githubusercontent.com/22262296/45079504-06a7c580-b0f3-11e8-896d-00b802a25639.png">


```
Scenario: Being unable to add multiple payment methods
    When I create a new order for "jon.snow@the-wall.com" and channel "United States"
    And I select "Cash on Delivery" payment method
    Then adding another payment method should not be possible
```

Fixes https://github.com/Sylius/AdminOrderCreationPlugin/issues/52