### PR TITLE
Make plugin possible to be installed with SymfonyFlex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "sylius/admin-order-creation-plugin",
-    "type": "sylius-plugin",
+    "type": "symfony-bundle",
+    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "admin order creation"],
     "description": "Sylius Plugin for order creation in Admin panel",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Following an approach proposed in https://github.com/Sylius/RefundPlugin/pull/69 and in https://github.com/Sylius/PluginSkeleton/pull/123/files