### PR TITLE
[Customer Repository] Ignore unecessary data

### DIFF
--- a/src/Doctrine/ORM/CustomerRepository.php
+++ b/src/Doctrine/ORM/CustomerRepository.php
@@ -13,7 +13,7 @@ final class CustomerRepository extends BaseCustomerRepository implements Custome
         return $this
             ->_em
             ->createQueryBuilder()
-            ->select('o.email')
+            ->select('o.id', 'o.email')
             ->from($this->_entityName, 'o')
             ->andWhere('o.email LIKE :email')
             ->setParameter('email', '%' . $email . '%')

--- a/src/Doctrine/ORM/CustomerRepository.php
+++ b/src/Doctrine/ORM/CustomerRepository.php
@@ -10,7 +10,11 @@ final class CustomerRepository extends BaseCustomerRepository implements Custome
 {
     public function findByEmailPart(string $email): array
     {
-        return $this->createQueryBuilder('o')
+        return $this
+            ->_em
+            ->createQueryBuilder()
+            ->select('o.email')
+            ->from($this->_entityName, 'o')
             ->andWhere('o.email LIKE :email')
             ->setParameter('email', '%' . $email . '%')
             ->getQuery()


### PR DESCRIPTION
When you have a lot of customers, the JSON result is too big so we limit the result to email without unecessary data (gender, name …)