### PR TITLE
Moved admin ajax requests to "admin" path prefix

### DIFF
--- a/src/Resources/config/app/routing.yml
+++ b/src/Resources/config/app/routing.yml
@@ -91,7 +91,7 @@ sylius_admin_order_creation_reorder:
                 arguments: ["expr:service('sylius.repository.order').find($id)"]
 
 sylius_admin_order_creation_ajax:
-    prefix: /ajax
+    prefix: admin/ajax
     resource: "@SyliusAdminOrderCreationPlugin/Resources/config/app/ajax.yml"
 
 fos_js_routing:


### PR DESCRIPTION
To enable compatibility with the RBAC plugin, ajax requests in admin should contain the "admin" prefix, to make sylius/symfony handle such requests with the "admin" firewall, rather than the "shop" firewall, which is selected for the status quo.

Since that firewall might have a current token (which is most likely not an admin) or no token, the request will be authenticated as "anon." which crashes the RBAC AccessCheckListener as well as it is not good practice.