### PR TITLE
Remove products label

### DIFF
--- a/src/Form/Type/NewOrderType.php
+++ b/src/Form/Type/NewOrderType.php
@@ -56,7 +56,7 @@ final class NewOrderType extends AbstractResourceType
                 $event
                     ->getForm()
                     ->add('items', CollectionType::class, [
-                        'label' => 'sylius.ui.items',
+                        'label' => false,
                         'entry_type' => OrderItemType::class,
                         'entry_options' => [
                             'currency' => $order->getCurrencyCode(),


### PR DESCRIPTION
Since there is already the accordeon title in the form, the label is redundant.