### PR TITLE
Find product even if translation does not exist

### DIFF
--- a/src/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Doctrine/ORM/ProductVariantRepository.php
@@ -13,7 +13,7 @@ final class ProductVariantRepository extends BaseProductVariantRepository implem
         $expr = $this->getEntityManager()->getExpressionBuilder();
 
         return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->innerJoin('o.product', 'p')
             ->innerJoin('p.channels', 'c')
             ->andWhere('c.code = :channel')


### PR DESCRIPTION
When I create an order if products don't have translation in my locale, I can't select a product.

I think we should access to all products even if translation doesn't exist.