### PR TITLE
Check if transition can be applied before apply it during order creation

### DIFF
--- a/spec/EventListener/OrderCreationListenerSpec.php
+++ b/spec/EventListener/OrderCreationListenerSpec.php
@@ -43,10 +43,10 @@ final class OrderCreationListenerSpec extends ObjectBehavior
         $event->getSubject()->willReturn($order);
 
         $stateMachineFactory->get($order, 'sylius_order_checkout')->willReturn($stateMachine);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS)->shouldBeCalled();
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)->shouldBeCalled();
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->shouldBeCalled();
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_ADDRESS)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)->shouldBeCalled();
 
         $this->completeOrderBeforeCreation($event);
     }

--- a/src/EventListener/OrderCreationListener.php
+++ b/src/EventListener/OrderCreationListener.php
@@ -40,9 +40,17 @@ final class OrderCreationListener
         Assert::isInstanceOf($order, OrderInterface::class);
 
         $stateMachine = $this->stateMachineFactory->get($order, 'sylius_order_checkout');
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
+        $transitions = [
+            OrderCheckoutTransitions::TRANSITION_ADDRESS,
+            OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING,
+            OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT,
+            OrderCheckoutTransitions::TRANSITION_COMPLETE,
+        ];
+    
+        foreach ($transitions as $transition) {
+            if ($stateMachine->can($transition)) {
+                $stateMachine->apply($transition);
+            }
+        }
     }
 }


### PR DESCRIPTION
fixes #132 

Apply transition only if we can apply it.
During virtual order creation, this avoid the exception : `Transition "select_shipping" cannot be applied on state "shipping_skipped" of object "App\Entity\Order\Order" with graph "sylius_order_checkout"`
