### PR TITLE
Changed conditional for offline gateway

### DIFF
--- a/src/EventListener/PaymentLinkCreationListener.php
+++ b/src/EventListener/PaymentLinkCreationListener.php
@@ -51,7 +51,7 @@ final class PaymentLinkCreationListener
         /** @var GatewayConfigInterface $gatewayConfig */
         $gatewayConfig = $paymentMethod->getGatewayConfig();
 
-        if ('offline' === $gatewayConfig->getGatewayName()) {
+        if ('Offline' === $gatewayConfig->getGatewayName()) {
             return;
         }
 


### PR DESCRIPTION
Apparently because of `payum/payum/src/Payum/Offline/OfflineGatewayFactory.php:23`, the gateway name for offline payments is now `Offline` instead of `offline`.