### PR TITLE
Fix 'Unknown "locale" filter' error

### DIFF
--- a/src/Resources/views/Order/preview.html.twig
+++ b/src/Resources/views/Order/preview.html.twig
@@ -28,7 +28,7 @@
                                 {% include [('@SyliusAdmin/Order/Label/State' ~ '/' ~ order.state ~ '.html.twig'), '@SyliusUi/Label/_default.html.twig'] with {'value': ('sylius.ui.' ~ order.state)|trans} %}
                             </div>
                             <div class="item" id="sylius-order-locale-code">
-                                {{ flags.fromLocaleCode(order.localeCode) }}{{ order.localeCode|locale }}
+                                {{ flags.fromLocaleCode(order.localeCode) }}{{ order.localeCode|sylius_locale_name }}
                             </div>
                             <div class="item">
                                 {{ 'sylius.ui.purchased_from'|trans }}


### PR DESCRIPTION
This prevents a 500 error. According to my tests, it's the only change needed to make this plugin compatible with 1.7