### PR TITLE
Allow to have no payment method

### DIFF
--- a/features/creating_order/creating_order_without_payment.feature
+++ b/features/creating_order/creating_order_without_payment.feature
@@ -1,0 +1,24 @@
+@admin_order_creation_managing_orders @stipe
+Feature: Creating order without payment if order is free
+    In order to place a free order in the name of a Customer
+    As an Administrator
+    I want to be able to create an order without payment in Admin panel
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Stark Coat" priced at "$0"
+        And the store ships everywhere for free
+        And there is a customer account "jon.snow@the-wall.com"
+        And I am logged in as an administrator
+
+    @ui @javascript @email
+    Scenario: Creating an order without payment for an existing customer
+        When I create a new order for "jon.snow@the-wall.com" and channel "United States"
+        And I add "Stark Coat" to this order
+        And I specify this order shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I select "Free" shipping method
+        And I place and confirm this order
+        Then I should be notified that order has been successfully created
+        And there should be no payment displayed next to order's payment
+        And there should be no payment link sent to "jon.snow@the-wall.com"
+#        And there should be one not paid nor shipped order with channel "United States" for "jon.snow@the-wall.com" in the registry

--- a/features/creating_order/creating_order_without_payment.feature
+++ b/features/creating_order/creating_order_without_payment.feature
@@ -1,4 +1,4 @@
-@admin_order_creation_managing_orders @stipe
+@admin_order_creation_managing_orders
 Feature: Creating order without payment if order is free
     In order to place a free order in the name of a Customer
     As an Administrator

--- a/features/creating_order/creating_order_without_payment.feature
+++ b/features/creating_order/creating_order_without_payment.feature
@@ -21,4 +21,3 @@ Feature: Creating order without payment if order is free
         Then I should be notified that order has been successfully created
         And there should be no payment displayed next to order's payment
         And there should be no payment link sent to "jon.snow@the-wall.com"
-#        And there should be one not paid nor shipped order with channel "United States" for "jon.snow@the-wall.com" in the registry

--- a/spec/EventListener/OrderCreationListenerSpec.php
+++ b/spec/EventListener/OrderCreationListenerSpec.php
@@ -45,7 +45,26 @@ final class OrderCreationListenerSpec extends ObjectBehavior
         $stateMachineFactory->get($order, 'sylius_order_checkout')->willReturn($stateMachine);
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS)->shouldBeCalled();
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->willReturn(true);
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->shouldBeCalled();
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE)->shouldBeCalled();
+
+        $this->completeOrderBeforeCreation($event);
+    }
+
+    function it_completes_order_without_payment_before_creation(
+        FactoryInterface $stateMachineFactory,
+        GenericEvent $event,
+        StateMachineInterface $stateMachine,
+        OrderInterface $order
+    ) {
+        $event->getSubject()->willReturn($order);
+
+        $stateMachineFactory->get($order, 'sylius_order_checkout')->willReturn($stateMachine);
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS)->shouldBeCalled();
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)->shouldBeCalled();
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->willReturn(false);
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)->shouldNotBeCalled();
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE)->shouldBeCalled();
 
         $this->completeOrderBeforeCreation($event);

--- a/src/EventListener/OrderCreationListener.php
+++ b/src/EventListener/OrderCreationListener.php
@@ -42,7 +42,9 @@ final class OrderCreationListener
         $stateMachine = $this->stateMachineFactory->get($order, 'sylius_order_checkout');
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS);
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
+        if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)) {
+            $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
+        }
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
     }
 }

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -7,7 +7,7 @@
     <class name="Sylius\Component\Core\Model\Order">
         <property name="payments">
             <constraint name="Count">
-                <option name="min">1</option>
+                <option name="min">0</option>
                 <option name="max">1</option>
                 <option name="groups">sylius</option>
             </constraint>

--- a/tests/Behat/Context/Admin/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Admin/ManagingOrdersContext.php
@@ -362,6 +362,14 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then there should be no payment displayed next to order's payment
+     */
+    public function thereShouldBeNoPaymentDisplayedNextToOrderPayment(): void
+    {
+        Assert::true($this->orderShowPage->hasNoPaymentBlock());
+    }
+
+    /**
      * @Then there should be a payment link sent to :email
      */
     public function thereShouldBePaymentLinkSentTo(string $email): void

--- a/tests/Behat/Page/Admin/OrderShowPage.php
+++ b/tests/Behat/Page/Admin/OrderShowPage.php
@@ -14,4 +14,16 @@ final class OrderShowPage extends ShowPage implements OrderShowPageInterface
 
         return null !== $lastPayment->find('css', '#payment-link');
     }
+
+    public function hasNoPaymentBlock(): bool
+    {
+        return null !== $this->getElement('no-payments');
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'no-payments' => '#no-payments',
+        ]);
+    }
 }

--- a/tests/Behat/Page/Admin/OrderShowPageInterface.php
+++ b/tests/Behat/Page/Admin/OrderShowPageInterface.php
@@ -9,4 +9,6 @@ use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
 interface OrderShowPageInterface extends ShowPageInterface
 {
     public function hasPaymentLink(): bool;
+
+    public function hasNoPaymentBlock(): bool;
 }


### PR DESCRIPTION
In case an order is free, we don't want to force a payment method since there is no payment at all.

Fixes #130.

This works perfectly on our projects, in Front and in Admin.