### PR TITLE
Fix state machine exception on order creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /tests/Application/yarn.lock
 
 /web/media
+
+/.phpunit.result.cache

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":[]}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":1,"defects":[],"times":[]}

--- a/src/EventListener/OrderCreationListener.php
+++ b/src/EventListener/OrderCreationListener.php
@@ -41,7 +41,9 @@ final class OrderCreationListener
 
         $stateMachine = $this->stateMachineFactory->get($order, 'sylius_order_checkout');
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS);
-        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
+        if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)) {
+            $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
+        }
         if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)) {
             $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
         }


### PR DESCRIPTION
This is similar to already existing PR, but i think original poster stopped responding so I can try to get that working. 


Issue:
https://github.com/Sylius/AdminOrderCreationPlugin/pull/134

However, the issue also appears when product is not virtual, but skipping_shipping_step_allowed in channel

PR:
https://github.com/Sylius/AdminOrderCreationPlugin/issues/132
