### PR TITLE
[API] Add missing "Autocomplete" serialization group

### DIFF
--- a/src/Resources/config/app/ajax.yml
+++ b/src/Resources/config/app/ajax.yml
@@ -46,6 +46,7 @@ sylius_admin_order_creation_ajax_product_variant_by_codes:
         _format: json
         _sylius:
             permission: true
+            serialization_groups: [Autocomplete]
             repository:
                 method: findOneByCode
                 arguments: $code


### PR DESCRIPTION
We should add this serialization group to the second product variant endpoint as well. 

Ref. #160

Based on #179