### PR TITLE
switch to Laminas\Stdlib

### DIFF
--- a/src/ReorderProcessing/CompositeReorderProcessor.php
+++ b/src/ReorderProcessing/CompositeReorderProcessor.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\AdminOrderCreationPlugin\ReorderProcessing;
 
+use Laminas\Stdlib\PriorityQueue;
 use Sylius\Component\Core\Model\OrderInterface;
-use Zend\Stdlib\PriorityQueue;
 
 final class CompositeReorderProcessor implements ReorderProcessor
 {


### PR DESCRIPTION
Issue:
#180

Will break the plugin for previous versions of Sylius that use `Zend\Stdlib` instead of `Laminas\Stdlib`.