### PR TITLE
[Maintenance] Allow flex plugin during plugin installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,11 @@
             "vendor/bin/ecs check src/ spec/ --fix"
         ]
     },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"


### PR DESCRIPTION
Follow up of https://github.com/Sylius/Sylius/pull/14106