### PR TITLE
Fix variant autocomplete label not correctly loaded on edit

### DIFF
--- a/src/Resources/config/app/ajax.yml
+++ b/src/Resources/config/app/ajax.yml
@@ -48,7 +48,7 @@ sylius_admin_order_creation_ajax_product_variant_by_codes:
             permission: true
             serialization_groups: [Autocomplete]
             repository:
-                method: findOneByCode
+                method: findByCode
                 arguments: $code
 
 sylius_admin_order_creation_ajax_provide_available_shipping_methods:


### PR DESCRIPTION
this causes an error in the autocomplete because it is expecting a collection: `response.forEach((item)`
```
if (autocompleteValue.split(',').filter(String).length > 0) {
        const menuElement = element.find('div.menu');

        menuElement.api({
          on: 'now',
          method: 'GET',
          url: loadForEditUrl,
          beforeSend(settings) {
            /* eslint-disable-next-line no-param-reassign */
            settings.data[choiceValue] = autocompleteValue.split(',').filter(String);

            return settings;
          },
          onSuccess(response) {
            response.forEach((item) => {
              menuElement.append((
                $(`<div class="item" data-value="${item[choiceValue]}">${item[choiceName]}</div>`)
              ));
            });

            element.dropdown('refresh');
            element.dropdown('set selected', element.find('input.autocomplete').val().split(',').filter(String));
          },
        });
      }
```